### PR TITLE
Allow mapping files as input

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -11,8 +11,11 @@
 #include <APPX/File.h>
 #include <cassert>
 #include <exception>
+#include <fstream>
 #include <fts.h>
+#include <iostream>
 #include <memory>
+#include <sstream>
 #include <unistd.h>
 #include <unordered_map>
 #include <vector>
@@ -101,6 +104,150 @@ void GetArchiveFileList(const char *path,
     }
 }
 
+class MalformedMappingFileError : public std::exception
+{
+public:
+    explicit MalformedMappingFileError(off_t lineNumber)
+        : lineNumber(lineNumber)
+    {
+        this->SetFileName(nullptr);
+    }
+
+    const char *what() const noexcept override
+    {
+        return this->message.c_str();
+    }
+
+    void SetFileName(const char *fileName)
+    {
+        if (!fileName || strcmp(fileName, "") == 0) {
+            fileName = "(unknown)";
+        }
+        std::ostringstream ss;
+        ss << "Malformed mapping file: " << fileName << ":" << this->lineNumber;
+        this->message = ss.str();
+    }
+
+private:
+    std::string message;
+    off_t lineNumber;
+};
+
+bool GetLine(std::istream &file, std::string &out, char delimiter)
+{
+    try {
+        std::getline(file, out, delimiter);
+    } catch (std::ios_base::failure &e) {
+        if (file.fail() || file.eof()) {
+            // Handled below.
+        } else {
+            throw;
+        }
+    }
+    if (file.bad()) {
+        return false;
+    }
+    if (file.eof()) {
+        if (file.fail() && out.empty()) {
+            // Don't treat starting at EOF as a failure.
+            file.clear(file.rdstate() & ~std::istream::failbit);
+            return false;
+        } else {
+            // We parsed something and reached EOF. Process the line.
+            return true;
+        }
+    }
+    return true;
+}
+
+void GetArchiveFileListFromMappingFile(
+    std::istream &mappingFile,
+    std::unordered_map<std::string, std::string> &fileNames)
+{
+    static const char kWhitespace[] = " \t";
+    // TODO(strager): Make this parser more accepting. This parser is way too
+    // strict.
+    bool didReadHeader = false;
+    off_t lineNumber = 1;
+    for (;;) {
+        std::string line;
+        if (!GetLine(mappingFile, line, '\n')) {
+            break;
+        }
+        if (mappingFile.fail()) {
+            // The line is too long.
+            throw MalformedMappingFileError(lineNumber);
+        }
+
+        // Trim leading and trailing whitespace and ignore blank lines.
+        {
+            auto first = line.find_first_not_of(kWhitespace);
+            if (first == std::string::npos) {
+                // Blank line.
+                continue;
+            }
+            auto last = line.find_last_not_of(kWhitespace);
+            assert(last != std::string::npos);
+            line.erase(last + 1, std::string::npos);
+            line.erase(0, first);
+        }
+        if (didReadHeader) {
+            // Parse the following:
+            //
+            //     "localPath" "archiveName"
+            //
+            // TODO(strager): Parse escaped quotes and other characters.
+            std::string::size_type quote1 = 0;
+            if (line[quote1] != '"') {
+                // Garbage before the first quote.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            auto quote2 = line.find('"', quote1 + 1);
+            if (quote2 == std::string::npos) {
+                // Missing the second quote.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            if (quote2 == quote1 + 1) {
+                // Empty local path.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            auto quote3 = line.find_first_not_of(kWhitespace, quote2 + 1);
+            if (quote3 == std::string::npos) {
+                // Missing the archive name.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            if (line[quote3] != '"') {
+                // Garbage between the second and third quotes.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            auto quote4 = line.find('"', quote3 + 1);
+            if (quote4 == std::string::npos) {
+                // Missing the fourth quote.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            if (quote4 == quote3 + 1) {
+                // Empty archive path.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            if (quote4 != line.size() - 1) {
+                // Garbage after the fourth quote.
+                throw MalformedMappingFileError(lineNumber);
+            }
+            std::string localPath =
+                line.substr(quote1 + 1, quote2 - quote1 - 1);
+            std::string archiveName =
+                line.substr(quote3 + 1, quote4 - quote3 - 1);
+            fileNames.emplace(std::move(archiveName), std::move(localPath));
+        } else {
+            if (line != "[Files]") {
+                throw MalformedMappingFileError(lineNumber);
+            }
+            didReadHeader = true;
+        }
+        lineNumber += 1;
+    }
+}
+
 void PrintUsage(const char *programName)
 {
     fprintf(stderr,
@@ -109,6 +256,8 @@ void PrintUsage(const char *programName)
             "\n"
             "Options:\n"
             "  -c pfx-file   sign the APPX with the private key file\n"
+            "  -f map-file   specify inputs from a mapping file\n"
+            "  -f -          specify a mapping file through standard input\n"
             "  -h            show this usage text and exit\n"
             "  -o appx-file  write the APPX to the file (required)\n"
             "  -0, -1, -2, -3, -4, -5, -6, -7, -8, -9\n"
@@ -120,7 +269,13 @@ void PrintUsage(const char *programName)
             "  A directory, indicating that all files and subdirectories \n"
             "    of that directory are included in the package, or\n"
             "  A file name, indicating that the file is included in the \n"
-            "    root of the package.\n"
+            "    root of the package, or\n"
+            "  A mapping file specified with the -f option.\n"
+            "\n"
+            "A mapping file has the following form:\n"
+            "\n"
+            "  [Files]\n"
+            "  \"/path/to/local/file.exe\" \"appx_file.exe\"\n"
             "\n"
             "Supported target systems:\n"
             "  Windows 10 (UAP)\n"
@@ -134,7 +289,8 @@ int main(int argc, char **argv) try {
     const char *certPath = NULL;
     const char *appxPath = NULL;
     int compressionLevel = Z_NO_COMPRESSION;
-    while (int c = getopt(argc, argv, "0123456789c:ho:")) {
+    std::unordered_map<std::string, std::string> fileNames;
+    while (int c = getopt(argc, argv, "0123456789c:f:ho:")) {
         if (c == -1) {
             break;
         }
@@ -153,6 +309,24 @@ int main(int argc, char **argv) try {
                 break;
             case 'c':
                 certPath = optarg;
+                break;
+            case 'f':
+                if (strcmp(optarg, "-") == 0) {
+                    std::cin.exceptions(std::istream::badbit |
+                                        std::istream::failbit);
+                    GetArchiveFileListFromMappingFile(std::cin, fileNames);
+                } else {
+                    std::ifstream file;
+                    file.exceptions(std::ifstream::badbit |
+                                    std::ifstream::failbit);
+                    file.open(optarg);
+                    try {
+                        GetArchiveFileListFromMappingFile(file, fileNames);
+                    } catch (MalformedMappingFileError &e) {
+                        e.SetFileName(optarg);
+                        throw;
+                    }
+                }
                 break;
             case 'o':
                 appxPath = optarg;
@@ -173,12 +347,6 @@ int main(int argc, char **argv) try {
     }
     argc -= optind;
     argv += optind;
-    if (argc <= 0) {
-        fprintf(stderr, "Missing inputs\n");
-        PrintUsage(programName);
-        return 1;
-    }
-    std::unordered_map<std::string, std::string> fileNames;
     for (char *const *i = argv; i != argv + argc; ++i) {
         const char *arg = *i;
         const char *equalSeparator = strchr(arg, '=');
@@ -190,6 +358,11 @@ int main(int argc, char **argv) try {
             // Local path specified. Infer archive path.
             GetArchiveFileList(arg, fileNames);
         }
+    }
+    if (fileNames.empty()) {
+        fprintf(stderr, "Missing inputs\n");
+        PrintUsage(programName);
+        return 1;
     }
     std::string certPathString = certPath ?: "";
     FilePtr appx = Open(appxPath, "wb");

--- a/Tests/TestInputs.py
+++ b/Tests/TestInputs.py
@@ -10,6 +10,7 @@
 
 from appx.util import appx_exe
 import appx.util
+import errno
 import os
 import subprocess
 import unittest
@@ -70,6 +71,155 @@ class TestInputs(unittest.TestCase):
                 self.assertIn('README.txt', zip.namelist())
                 self.assertNotIn('other_file.dll', zip.namelist())
                 self.assertIn('somedir/other_file.dll', zip.namelist())
+
+    def test_mapping_file(self):
+        with appx.util.temp_dir() as d:
+            with open(os.path.join(d, 'README.txt'), 'wb') as readme:
+                readme.write('This is a test file.\n')
+            with open(os.path.join(d, 'other_file.dll'), 'wb') as other_file:
+                other_file.write('MZ')
+            with open(os.path.join(d, 'mapping.txt'), 'w') as mapping_file:
+                mapping_file.write(
+                    '[Files]\n'
+                    '"{}" "README.txt"\n'
+                    '"{}" "somedir/other_file.dll"\n'.format(
+                        self.__quote_mapping_file_path(
+                            os.path.join(d, 'README.txt')),
+                        self.__quote_mapping_file_path(
+                            os.path.join(d, 'other_file.dll'))))
+            subprocess.check_call([
+                appx_exe(), '-o', os.path.join(d, 'test.appx'),
+                '-f', os.path.join(d, 'mapping.txt'),
+            ])
+            with zipfile.ZipFile(os.path.join(d, 'test.appx')) as zip:
+                self.assertIn('README.txt', zip.namelist())
+                self.assertNotIn('other_file.dll', zip.namelist())
+                self.assertIn('somedir/other_file.dll', zip.namelist())
+
+    def test_mapping_file_missing(self):
+        with appx.util.temp_dir() as d:
+            process = subprocess.Popen([
+                appx_exe(), '-o', os.path.join(d, 'test.appx'),
+                '-f', os.path.join(d, 'mapping.txt'),
+            ], stderr=subprocess.PIPE)
+            (_, stderr) = process.communicate()
+            self.assertEqual(1, process.returncode)
+            self.assertNotIn('Malformed', stderr)
+            # TODO(strager)
+            #self.assertIn('mapping.txt', stderr)
+            #self.assertIn('no such file', stderr)
+
+    def test_mapping_file_syntax(self):
+        with appx.util.temp_dir() as d:
+            with open(os.path.join(d, 'README.txt'), 'wb') as readme:
+                readme.write('This is a test file.\n')
+            mapping_file_test_cases = [
+                # One file.
+                '[Files]\n"{}" "README.txt"'.format(
+                    self.__quote_mapping_file_path(
+                        os.path.join(d, 'README.txt'))),
+                '[Files]\n"{}" "README.txt"\n'.format(
+                    self.__quote_mapping_file_path(
+                        os.path.join(d, 'README.txt'))),
+
+                # Empty lines.
+                (
+                    '\n'
+                    '[Files]\n'
+                    '\n'
+                    '\n'
+                    '"{}" "README.txt"\n'
+                    '\n'.format(self.__quote_mapping_file_path(
+                        os.path.join(d, 'README.txt')))),
+
+                # Whitespace.
+                (
+                    ' \n'
+                    '[Files]\n'
+                    ' \t\n'
+                    '   \n'
+                    ' "{}" "README.txt"\t\n'
+                    ' \n'.format(self.__quote_mapping_file_path(
+                        os.path.join(d, 'README.txt')))),
+            ]
+            for mapping_file_test_case in mapping_file_test_cases:
+                with open(os.path.join(d, 'mapping.txt'), 'w') as mapping_file:
+                    mapping_file.write(mapping_file_test_case)
+                try:
+                    os.remove(os.path.join(d, 'test.appx'))
+                except OSError as e:
+                    if e.errno == errno.ENOENT:
+                        # Ignore.
+                        pass
+                    else:
+                        raise
+                subprocess.check_call([
+                    appx_exe(), '-o', os.path.join(d, 'test.appx'),
+                    '-f', os.path.join(d, 'mapping.txt'),
+                ])
+                with zipfile.ZipFile(os.path.join(d, 'test.appx')) as zip:
+                    self.assertIn('README.txt', zip.namelist())
+
+    def test_mapping_file_corrupt_syntax(self):
+        with appx.util.temp_dir() as d:
+            mapping_file_test_cases = [
+                '[Files',
+                '[Files]\n"',
+                '[Files]\n"{}" "README.txt" ""\n'.format(
+                    self.__quote_mapping_file_path(
+                        os.path.join(d, 'README.txt'))),
+            ]
+            for mapping_file_test_case in mapping_file_test_cases:
+                with open(os.path.join(d, 'mapping.txt'), 'w') as mapping_file:
+                    mapping_file.write(mapping_file_test_case)
+                try:
+                    os.remove(os.path.join(d, 'test.appx'))
+                except OSError as e:
+                    if e.errno == errno.ENOENT:
+                        # Ignore.
+                        pass
+                    else:
+                        raise
+                process = subprocess.Popen([
+                    appx_exe(), '-o', os.path.join(d, 'test.appx'),
+                    '-f', os.path.join(d, 'mapping.txt'),
+                ], stderr=subprocess.PIPE)
+                (_, stderr) = process.communicate()
+                self.assertEqual(1, process.returncode)
+                self.assertIn('mapping.txt', stderr)
+                self.assertIn('Malformed', stderr)
+
+    def test_mapping_file_stdin(self):
+        with appx.util.temp_dir() as d:
+            with open(os.path.join(d, 'README.txt'), 'wb') as readme:
+                readme.write('This is a test file.\n')
+            with open(os.path.join(d, 'other_file.dll'), 'wb') as other_file:
+                other_file.write('MZ')
+            mapping_file = (
+                '[Files]\n'
+                '"{}" "README.txt"\n'
+                '"{}" "somedir/other_file.dll"\n'.format(
+                    self.__quote_mapping_file_path(
+                        os.path.join(d, 'README.txt')),
+                    self.__quote_mapping_file_path(
+                        os.path.join(d, 'other_file.dll'))))
+            command = [
+                appx_exe(), '-o', os.path.join(d, 'test.appx'),
+                '-f', '-',
+            ]
+            process = subprocess.Popen(command, stdin=subprocess.PIPE)
+            (_, _) = process.communicate(mapping_file)
+            if process.returncode != 0:
+                raise subprocess.CalledProcessError(process.returncode, command)
+            with zipfile.ZipFile(os.path.join(d, 'test.appx')) as zip:
+                self.assertIn('README.txt', zip.namelist())
+                self.assertNotIn('other_file.dll', zip.namelist())
+                self.assertIn('somedir/other_file.dll', zip.namelist())
+
+    @staticmethod
+    def __quote_mapping_file_path(path):
+        # TODO(strager): Escape '"'.
+        return path
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, fb-util-for-appx accepts archive files via
command-line arguments. If there are many files to archive,
specifying individual files as command-line arguments hits
operating system limits in the length of the command. A
directory can be specified instead of individual files, but
constructing directories is sometimes expensive.

Accept APPX mapping files in addition the current inputs,
either via a mapping file on the filesystem or via standard
input. This allows users to create APPX archives with many
files without extra filesystem operations and cleanup.
