### PR TITLE
Add `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+This project adheres to the [Open Code of Conduct](http://todogroup.org/opencodeofconduct/#fb-util-for-appx/opensource@fb.com).
+By participating, you are expected to honor this code.


### PR DESCRIPTION
It's great that this project has a Code of Conduct! Github expects there to be a separate `CODE_OF_CONDUCT.md` file for their community standards - let's add this file in order to make it clear that this project has support for a healthy open source community.

why make this change?:
Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [fb-util-for-appx community profile
checklist](https://github.com/facebook/fb-util-for-appx/community) and increase the visibility of the COC for this project.

test plan:
Viewing it on my branch -
<img width="1026" alt="screen shot 2017-12-18 at 7 40 13 am" src="https://user-images.githubusercontent.com/1114467/34114117-ba58e8fc-e3c6-11e7-8028-cdb96fd0e8b0.png">


issue:
internal task t23481323